### PR TITLE
Dynamic `TileFetcher`

### DIFF
--- a/examples/label/src/main.rs
+++ b/examples/label/src/main.rs
@@ -15,7 +15,7 @@ use snapr::{
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(tile_fetcher)
+        .with_tile_fetcher(&tile_fetcher)
         .with_tile_size(256)
         .with_zoom(13)
         .build()?;

--- a/examples/open-street-maps/src/line/main.rs
+++ b/examples/open-street-maps/src/line/main.rs
@@ -2,7 +2,7 @@ use open_street_maps::tile_fetcher;
 use snapr::SnaprBuilder;
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(tile_fetcher)
+        .with_tile_fetcher(&tile_fetcher)
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/line_string/main.rs
+++ b/examples/open-street-maps/src/line_string/main.rs
@@ -4,7 +4,7 @@ use snapr::SnaprBuilder;
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(tile_fetcher)
+        .with_tile_fetcher(&tile_fetcher)
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/point/main.rs
+++ b/examples/open-street-maps/src/point/main.rs
@@ -3,7 +3,7 @@ use snapr::SnaprBuilder;
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(tile_fetcher)
+        .with_tile_fetcher(&tile_fetcher)
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/polygon/main.rs
+++ b/examples/open-street-maps/src/polygon/main.rs
@@ -4,7 +4,7 @@ use snapr::SnaprBuilder;
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(tile_fetcher)
+        .with_tile_fetcher(&tile_fetcher)
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -13,7 +13,7 @@ use tiny_skia::Color;
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(tile_fetcher)
+        .with_tile_fetcher(&tile_fetcher)
         .with_tile_size(256)
         .with_zoom(12)
         .build()?;

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -38,7 +38,7 @@ const SVG: &str = r##"
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(tile_fetcher)
+        .with_tile_fetcher(&tile_fetcher)
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/snapr/Cargo.toml
+++ b/snapr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapr"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Flexible and frictionless way to render snapshots of maps with stylized geometries."
 categories = ["science::geo"]
@@ -12,10 +12,10 @@ authors = { workspace = true }
 license = { workspace = true }
 
 [features]
-default = [ "drawing", "rayon", "svg" ]
-drawing = [ "dep:hex", "dep:tiny-skia" ]
-rayon = [ "dep:rayon" ]
-svg = [ "dep:resvg", "drawing" ]
+default = ["drawing", "rayon", "svg"]
+drawing = ["dep:hex", "dep:tiny-skia"]
+rayon = ["dep:rayon"]
+svg = ["dep:resvg", "drawing"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{Error, Snapr, TileFetcher};
 
 /// Builder structure for [`snapr`].
@@ -13,28 +15,28 @@ use crate::{Error, Snapr, TileFetcher};
 /// }
 ///
 /// let snapr = SnaprBuilder::new()
-///     .with_tile_fetcher(tile_fetcher)
+///     .with_tile_fetcher(&tile_fetcher)
 ///     .build();
 ///
 /// assert!(snapr.is_ok());
 /// ```
-#[derive(Debug, Default)]
-pub struct SnaprBuilder {
-    tile_fetcher: Option<TileFetcher>,
+#[derive(Default)]
+pub struct SnaprBuilder<'a> {
+    tile_fetcher: Option<TileFetcher<'a>>,
     tile_size: Option<u32>,
     height: Option<u32>,
     width: Option<u32>,
     zoom: Option<u8>,
 }
 
-impl SnaprBuilder {
+impl<'a> SnaprBuilder<'a> {
     /// Constructs a new [`SnaprBuilder`] to be used in constructing a [`Snapr`].
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Configures a [`TileFetcher`] to be used in the [`Snapr::tile_fetcher`] field.
-    pub fn with_tile_fetcher(self, tile_fetcher: TileFetcher) -> Self {
+    pub fn with_tile_fetcher(self, tile_fetcher: TileFetcher<'a>) -> Self {
         Self {
             tile_fetcher: Some(tile_fetcher),
             ..self
@@ -86,12 +88,12 @@ impl SnaprBuilder {
     /// }
     ///
     /// let snapr = SnaprBuilder::new()
-    ///     .with_tile_fetcher(tile_fetcher)
+    ///     .with_tile_fetcher(&tile_fetcher)
     ///     .build();
     ///
     /// assert!(snapr.is_ok());
     /// ```
-    pub fn build(self) -> Result<Snapr, Error> {
+    pub fn build(self) -> Result<Snapr<'a>, Error> {
         let Some(tile_fetcher) = self.tile_fetcher else {
             return Err(Error::Builder {
                 reason: "field `tile_fetcher` needs to be set prior to a `snapr` being built"
@@ -113,5 +115,16 @@ impl SnaprBuilder {
         };
 
         Ok(snapr)
+    }
+}
+
+impl<'a> fmt::Debug for SnaprBuilder<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SnaprBuilder")
+            .field("tile_size", &self.tile_size)
+            .field("height", &self.height)
+            .field("width", &self.width)
+            .field("zoom", &self.zoom)
+            .finish()
     }
 }


### PR DESCRIPTION
## Description

Converts the `TileFetcher` type to alias a `dyn Fn` to enable passing closures as a `TileFetcher`.
