### PR TITLE
Remove `Send` and `Sync` requirements from `TileFetcher` when `rayon` flag is not enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,22 @@ members = [
 resolver = "2"
 
 [workspace.package]
-authors = [
-    "c1m50c <58411864+c1m50c@users.noreply.github.com>"
-]
+authors = ["c1m50c <58411864+c1m50c@users.noreply.github.com>"]
 license = "MIT"
+version = "0.3.1"
 
 [workspace.dependencies]
 anyhow = "1.0.89"
 geo = "0.28.0"
 hex = "0.4.3"
-image = { version = "0.25.2", default-features = false, features = ["jpeg", "png"] }
+image = { version = "0.25.2", default-features = false, features = [
+    "jpeg",
+    "png",
+] }
 rayon = "1.10.0"
 resvg = "0.44.0"
 thiserror = "1.0.64"
-tiny-skia = { version = "0.11.4", default-features = false, features = ["simd", "std"] }
+tiny-skia = { version = "0.11.4", default-features = false, features = [
+    "simd",
+    "std",
+] }

--- a/snapr/Cargo.toml
+++ b/snapr/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "snapr"
-version = "0.3.0"
 edition = "2021"
 description = "Flexible and frictionless way to render snapshots of maps with stylized geometries."
 categories = ["science::geo"]
@@ -8,8 +7,9 @@ keywords = ["geo", "geography", "geospatial", "maps"]
 repository = "https://github.com/c1m50c/snapr"
 
 # Shared Package Configuration
-authors = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+license.workspace = true
+version.workspace = true
 
 [features]
 default = ["drawing", "rayon", "svg"]
@@ -18,11 +18,11 @@ rayon = ["dep:rayon"]
 svg = ["dep:resvg", "drawing"]
 
 [dependencies]
-anyhow = { workspace = true }
-geo = { workspace = true }
+anyhow.workspace = true
+geo.workspace = true
 hex = { workspace = true, optional = true }
-image = { workspace = true }
+image.workspace = true
 rayon = { workspace = true, optional = true }
 resvg = { workspace = true, optional = true }
-thiserror = { workspace = true }
+thiserror.workspace = true
 tiny-skia = { workspace = true, optional = true }

--- a/snapr/src/lib.rs
+++ b/snapr/src/lib.rs
@@ -57,8 +57,23 @@ pub enum Error {
 ///     todo!()
 /// }
 /// ```
+#[cfg(feature = "rayon")]
 pub type TileFetcher<'a> =
     &'a (dyn Fn(i32, i32, u8) -> Result<image::DynamicImage, Error> + Send + Sync);
+
+/// Function that takes coordinates and a zoom level as arguments and returns an [`Image`](image::DynamicImage) of the map tile at the given position.
+///
+/// ## Example
+///
+/// ```rust
+/// use image::DynamicImage;
+///
+/// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, snapr::Error> {
+///     todo!()
+/// }
+/// ```
+#[cfg(not(feature = "rayon"))]
+pub type TileFetcher<'a> = &'a dyn Fn(i32, i32, u8) -> Result<image::DynamicImage, Error>;
 
 /// Utility structure to generate snapshots.
 /// Should be normally constructed through building with [`SnaprBuilder`].


### PR DESCRIPTION
## Description

Small little change to make `TileFetcher` more easily used in single-threaded environments.
