### PR TITLE
Batch Tile Fetcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "examples/batch",
     "examples/label",
     "examples/open-street-maps",
     "examples/svg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 authors = ["c1m50c <58411864+c1m50c@users.noreply.github.com>"]
 license = "MIT"
-version = "0.3.1"
+version = "0.4.0"
 
 [workspace.dependencies]
 anyhow = "1.0.89"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ Each [`Geometry`](https://docs.rs/geo/latest/geo/geometry/enum.Geometry.html) pr
 
 ## Examples
 
+### [Batch](./examples/batch/)
+
+Demonstrates how to use a `BatchTileFetcher`.
+
+#### Running
+
+```shell
+cargo run -p "batch"
+```
+
 ### [Label](./examples/label/)
 
 Demonstrates how to use `LabelOptions` to draw a label on a geometry.

--- a/examples/batch/Cargo.toml
+++ b/examples/batch/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "batch"
+edition = "2021"
+publish = false
+
+# Shared Package Configuration
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+geo = { workspace = true }
+image = { workspace = true }
+reqwest = { version = "0.12.7", features = ["blocking"] }
+snapr = { path = "../../snapr" }

--- a/examples/batch/README.md
+++ b/examples/batch/README.md
@@ -1,0 +1,9 @@
+# examples/batch
+
+Demonstrates how to use a `BatchTileFetcher`.
+
+## Running
+
+```shell
+cargo run -p "batch"
+```

--- a/examples/batch/src/main.rs
+++ b/examples/batch/src/main.rs
@@ -1,0 +1,53 @@
+use std::io::Cursor;
+
+use image::{DynamicImage, ImageFormat, ImageReader};
+use reqwest::blocking::ClientBuilder;
+use snapr::{SnaprBuilder, TileFetcher};
+
+fn main() -> Result<(), anyhow::Error> {
+    let snapr = SnaprBuilder::new()
+        .with_tile_fetcher(TileFetcher::Batch(&tile_fetcher))
+        .with_tile_size(256)
+        .with_zoom(15)
+        .build()?;
+
+    let geometry = geo::point!(x: 41.225683, y: -95.927762);
+
+    snapr
+        .generate_snapshot_from_geometry(geometry, &[])?
+        .save("example.png")?;
+
+    Ok(())
+}
+
+fn tile_fetcher(
+    coords: &[(i32, i32)],
+    zoom: u8,
+) -> Result<Vec<(i32, i32, DynamicImage)>, snapr::Error> {
+    let client = ClientBuilder::new()
+        .user_agent("snap")
+        .build()
+        .map_err(anyhow::Error::from)?;
+
+    let mut tiles = Vec::with_capacity(1_440_000);
+
+    for (x, y) in coords {
+        let address = format!("https://a.tile.osm.org/{zoom}/{x}/{y}.png");
+
+        let cursor = client
+            .get(&address)
+            .send()
+            .and_then(|response| response.error_for_status())
+            .and_then(|response| response.bytes())
+            .map(Cursor::new)
+            .map_err(anyhow::Error::from)?;
+
+        let mut image_reader = ImageReader::new(cursor);
+        image_reader.set_format(ImageFormat::Png);
+
+        let image = image_reader.decode().map_err(anyhow::Error::from)?;
+        tiles.push((*x, *y, image));
+    }
+
+    Ok(tiles)
+}

--- a/examples/label/src/main.rs
+++ b/examples/label/src/main.rs
@@ -4,12 +4,12 @@ use image::{DynamicImage, ImageFormat, ImageReader};
 use reqwest::blocking::ClientBuilder;
 use snapr::{
     drawing::{geometry::point::PointStyle, style::ColorOptions, svg::Label},
-    SnaprBuilder,
+    SnaprBuilder, TileFetcher,
 };
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(&tile_fetcher)
+        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
         .with_tile_size(256)
         .with_zoom(13)
         .build()?;

--- a/examples/open-street-maps/src/line/main.rs
+++ b/examples/open-street-maps/src/line/main.rs
@@ -1,9 +1,9 @@
 use open_street_maps::tile_fetcher;
-use snapr::SnaprBuilder;
+use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(&tile_fetcher)
+        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/line_string/main.rs
+++ b/examples/open-street-maps/src/line_string/main.rs
@@ -1,10 +1,10 @@
 use geo::line_string;
 use open_street_maps::tile_fetcher;
-use snapr::SnaprBuilder;
+use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(&tile_fetcher)
+        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/point/main.rs
+++ b/examples/open-street-maps/src/point/main.rs
@@ -1,9 +1,9 @@
 use open_street_maps::tile_fetcher;
-use snapr::SnaprBuilder;
+use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(&tile_fetcher)
+        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/polygon/main.rs
+++ b/examples/open-street-maps/src/polygon/main.rs
@@ -1,10 +1,10 @@
 use geo::polygon;
 use open_street_maps::tile_fetcher;
-use snapr::SnaprBuilder;
+use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(&tile_fetcher)
+        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -8,7 +8,7 @@ use snapr::{
         style::Style,
         svg::Svg,
     },
-    SnaprBuilder,
+    SnaprBuilder, TileFetcher,
 };
 
 // https://openmoji.org/library/emoji-1F686/
@@ -36,7 +36,7 @@ const SVG: &str = r##"
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(&tile_fetcher)
+        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Error, Snapr, TileFetcher};
+use crate::{Error, IndividualTileFetcher, Snapr};
 
 /// Builder structure for [`snapr`].
 ///
@@ -22,7 +22,7 @@ use crate::{Error, Snapr, TileFetcher};
 /// ```
 #[derive(Default)]
 pub struct SnaprBuilder<'a> {
-    tile_fetcher: Option<TileFetcher<'a>>,
+    tile_fetcher: Option<IndividualTileFetcher<'a>>,
     tile_size: Option<u32>,
     height: Option<u32>,
     width: Option<u32>,
@@ -36,7 +36,7 @@ impl<'a> SnaprBuilder<'a> {
     }
 
     /// Configures a [`TileFetcher`] to be used in the [`Snapr::tile_fetcher`] field.
-    pub fn with_tile_fetcher(self, tile_fetcher: TileFetcher<'a>) -> Self {
+    pub fn with_tile_fetcher(self, tile_fetcher: IndividualTileFetcher<'a>) -> Self {
         Self {
             tile_fetcher: Some(tile_fetcher),
             ..self

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -15,7 +15,7 @@ use crate::{Error, Snapr, TileFetcher};
 /// }
 ///
 /// let snapr = SnaprBuilder::new()
-///     .with_tile_fetcher(&tile_fetcher)
+///     .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
 ///     .build();
 ///
 /// assert!(snapr.is_ok());

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -8,7 +8,7 @@ use crate::{Error, Snapr, TileFetcher};
 ///
 /// ```rust
 /// use image::DynamicImage;
-/// use snapr::SnaprBuilder;
+/// use snapr::{SnaprBuilder, TileFetcher};
 ///
 /// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, snapr::Error> {
 ///     todo!()

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Error, IndividualTileFetcher, Snapr};
+use crate::{Error, Snapr, TileFetcher};
 
 /// Builder structure for [`snapr`].
 ///
@@ -22,7 +22,7 @@ use crate::{Error, IndividualTileFetcher, Snapr};
 /// ```
 #[derive(Default)]
 pub struct SnaprBuilder<'a> {
-    tile_fetcher: Option<IndividualTileFetcher<'a>>,
+    tile_fetcher: Option<TileFetcher<'a>>,
     tile_size: Option<u32>,
     height: Option<u32>,
     width: Option<u32>,
@@ -36,7 +36,7 @@ impl<'a> SnaprBuilder<'a> {
     }
 
     /// Configures a [`TileFetcher`] to be used in the [`Snapr::tile_fetcher`] field.
-    pub fn with_tile_fetcher(self, tile_fetcher: IndividualTileFetcher<'a>) -> Self {
+    pub fn with_tile_fetcher(self, tile_fetcher: TileFetcher<'a>) -> Self {
         Self {
             tile_fetcher: Some(tile_fetcher),
             ..self
@@ -81,14 +81,14 @@ impl<'a> SnaprBuilder<'a> {
     ///
     /// ```rust
     /// use image::DynamicImage;
-    /// use snapr::SnaprBuilder;
+    /// use snapr::{SnaprBuilder, TileFetcher};
     ///
     /// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, snapr::Error> {
     ///     todo!()
     /// }
     ///
     /// let snapr = SnaprBuilder::new()
-    ///     .with_tile_fetcher(&tile_fetcher)
+    ///     .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
     ///     .build();
     ///
     /// assert!(snapr.is_ok());

--- a/snapr/src/lib.rs
+++ b/snapr/src/lib.rs
@@ -7,6 +7,9 @@ use image::imageops::overlay;
 use thiserror::Error;
 use tiny_skia::Pixmap;
 
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
 #[cfg(feature = "drawing")]
 use drawing::style::Style;
 
@@ -75,11 +78,55 @@ pub type IndividualTileFetcher<'a> =
 #[cfg(not(feature = "rayon"))]
 pub type IndividualTileFetcher<'a> = &'a dyn Fn(i32, i32, u8) -> Result<image::DynamicImage, Error>;
 
+/// Function that takes in a slice of coordinates and a zoom level as arguments and returns the [`Images`](image::DynamicImage) of the map tiles at the given positions.
+///
+/// ## Example
+///
+/// ```rust
+/// use image::DynamicImage;
+///
+/// fn tile_fetcher(matrix: &[(i32, i32)], zoom: u8) -> Result<Vec<(i32, i32, DynamicImage)>, snapr::Error> {
+///     todo!()
+/// }
+/// ```
+// FIXME: `BatchTileFetcher` does not truly require `Send` or `Sync` when the `rayon` feature flag is enabled.
+// It's only here currently to get the `Snapr::overlay_backing_tiles::x_y_to_tile` closure to compile correctly.
+#[cfg(feature = "rayon")]
+pub type BatchTileFetcher<'a> = &'a (dyn Fn(&[(i32, i32)], u8) -> Result<Vec<(i32, i32, image::DynamicImage)>, Error>
+         + Send
+         + Sync);
+
+/// Function that takes in a slice of coordinates and a zoom level as arguments and returns the [`Images`](image::DynamicImage) of the map tiles at the given positions.
+///
+/// ## Example
+///
+/// ```rust
+/// use image::DynamicImage;
+///
+/// fn tile_fetcher(matrix: &[(i32, i32)], zoom: u8) -> Result<Vec<(i32, i32, DynamicImage)>, snapr::Error> {
+///     todo!()
+/// }
+/// ```
+#[cfg(not(feature = "rayon"))]
+pub type BatchTileFetcher<'a> =
+    &'a dyn Fn(&[(i32, i32)], u8) -> Result<Vec<(i32, i32, image::DynamicImage)>, Error>;
+
+/// Functions that return image(s) of map tiles at given coordinates.
+/// See each variant's documentation for more details.
+pub enum TileFetcher<'a> {
+    /// See [`IndividualTileFetcher`].
+    Individual(IndividualTileFetcher<'a>),
+
+    /// See [`BatchTileFetcher`].
+    Batch(BatchTileFetcher<'a>),
+}
+
 /// Utility structure to generate snapshots.
 /// Should be normally constructed through building with [`SnaprBuilder`].
 pub struct Snapr<'a> {
     /// Function that returns an image of a map tile at specified coordinates.
-    tile_fetcher: IndividualTileFetcher<'a>,
+    /// See [`TileFetcher`] for more details.
+    tile_fetcher: TileFetcher<'a>,
 
     /// Size of the image returned by the [`tile_fetcher`](Self::tile_fetcher).
     tile_size: u32,
@@ -242,28 +289,6 @@ impl<'a> Snapr<'a> {
         dbg!(zoom)
     }
 
-    /// Calls the [`tile_fetcher`](Self::tile_fetcher) function with the given coordinates and converts the returned [`image::DynamicImage`] into an [`image::RgbaImage`].
-    #[inline(always)]
-    fn get_tile(&self, x: i32, y: i32, zoom: u8) -> Result<image::RgbaImage, Error> {
-        let tile = (self.tile_fetcher)(x, y, zoom)?.to_rgba8();
-
-        if tile.height() != self.tile_size {
-            return Err(Error::IncorrectTileSize {
-                expected: self.tile_size,
-                received: tile.height(),
-            });
-        }
-
-        if tile.width() != self.tile_size {
-            return Err(Error::IncorrectTileSize {
-                expected: self.tile_size,
-                received: tile.height(),
-            });
-        }
-
-        Ok(tile)
-    }
-
     /// Fills the given `image` with tiles centered around the given `epsg_3857_center` point.
     fn overlay_backing_tiles(
         &self,
@@ -282,42 +307,65 @@ impl<'a> Snapr<'a> {
         let max_x = (epsg_3857_center.x() + required_columns).ceil() as i32;
         let max_y = (epsg_3857_center.y() + required_rows).ceil() as i32;
 
-        let x_y_to_tile = |(x, y): (i32, i32)| -> Result<(image::RgbaImage, i64, i64), Error> {
-            let tile = self.get_tile((x + n) % n, (y + n) % n, zoom)?;
+        match self.tile_fetcher {
+            TileFetcher::Individual(tile_fetcher) => {
+                let x_y_to_tile =
+                    |(x, y): (i32, i32)| -> Result<(image::RgbaImage, i64, i64), Error> {
+                        let tile = (tile_fetcher)((x + n) % n, (y + n) % n, zoom)?.to_rgba8();
 
-            let tile_coords = (geo::Point::from((x as f64, y as f64)) - epsg_3857_center)
-                .map_coords(|coord| geo::Coord {
-                    x: coord.x * self.tile_size as f64 + self.width as f64 / 2.0,
-                    y: coord.y * self.tile_size as f64 + self.height as f64 / 2.0,
-                });
+                        let tile_coords = (geo::Point::from((x as f64, y as f64))
+                            - epsg_3857_center)
+                            .map_coords(|coord| geo::Coord {
+                                x: coord.x * self.tile_size as f64 + self.width as f64 / 2.0,
+                                y: coord.y * self.tile_size as f64 + self.height as f64 / 2.0,
+                            });
 
-            Ok((tile, tile_coords.x() as i64, tile_coords.y() as i64))
-        };
+                        Ok((tile, tile_coords.x() as i64, tile_coords.y() as i64))
+                    };
 
-        #[cfg(feature = "rayon")]
-        {
-            use rayon::prelude::*;
+                #[cfg(feature = "rayon")]
+                {
+                    let matrix_iter = (min_x..max_x)
+                        .map(|x| (x, min_y..max_y))
+                        .flat_map(|(x, y)| y.map(move |y| (x, y)));
 
-            let matrix_iter = (min_x..max_x)
-                .map(|x| (x, min_y..max_y))
-                .flat_map(|(x, y)| y.map(move |y| (x, y)));
+                    let tiles = matrix_iter
+                        .par_bridge()
+                        .flat_map(x_y_to_tile)
+                        .collect::<Vec<_>>();
 
-            let tiles = matrix_iter
-                .par_bridge()
-                .flat_map(x_y_to_tile)
-                .collect::<Vec<_>>();
+                    tiles
+                        .into_iter()
+                        .for_each(|(tile, x, y)| overlay(image, &tile, x, y));
+                }
 
-            tiles
-                .into_iter()
-                .for_each(|(tile, x, y)| overlay(image, &tile, x, y));
-        }
+                #[cfg(not(feature = "rayon"))]
+                {
+                    for x in min_x..max_x {
+                        for y in min_y..max_y {
+                            let (tile, x, y) = x_y_to_tile((x, y))?;
+                            overlay(image, &tile, x, y);
+                        }
+                    }
+                }
+            }
 
-        #[cfg(not(feature = "rayon"))]
-        {
-            for x in min_x..max_x {
-                for y in min_y..max_y {
-                    let (tile, x, y) = x_y_to_tile((x, y))?;
-                    overlay(image, &tile, x, y);
+            TileFetcher::Batch(tile_fetcher) => {
+                let matrix = (min_x..max_x)
+                    .map(|x| (x, min_y..max_y))
+                    .flat_map(|(x, y)| y.map(move |y| (x, y)))
+                    .collect::<Vec<_>>();
+
+                let batches = tile_fetcher(&matrix, zoom)?;
+
+                for (x, y, tile) in batches {
+                    let tile_coords = (geo::Point::from((x as f64, y as f64)) - epsg_3857_center)
+                        .map_coords(|coord| geo::Coord {
+                            x: coord.x * self.tile_size as f64 + self.width as f64 / 2.0,
+                            y: coord.y * self.tile_size as f64 + self.height as f64 / 2.0,
+                        });
+
+                    overlay(image, &tile, tile_coords.x() as i64, tile_coords.y() as i64);
                 }
             }
         }

--- a/snapr/src/lib.rs
+++ b/snapr/src/lib.rs
@@ -58,7 +58,7 @@ pub enum Error {
 /// }
 /// ```
 #[cfg(feature = "rayon")]
-pub type TileFetcher<'a> =
+pub type IndividualTileFetcher<'a> =
     &'a (dyn Fn(i32, i32, u8) -> Result<image::DynamicImage, Error> + Send + Sync);
 
 /// Function that takes coordinates and a zoom level as arguments and returns an [`Image`](image::DynamicImage) of the map tile at the given position.
@@ -73,13 +73,13 @@ pub type TileFetcher<'a> =
 /// }
 /// ```
 #[cfg(not(feature = "rayon"))]
-pub type TileFetcher<'a> = &'a dyn Fn(i32, i32, u8) -> Result<image::DynamicImage, Error>;
+pub type IndividualTileFetcher<'a> = &'a dyn Fn(i32, i32, u8) -> Result<image::DynamicImage, Error>;
 
 /// Utility structure to generate snapshots.
 /// Should be normally constructed through building with [`SnaprBuilder`].
 pub struct Snapr<'a> {
     /// Function that returns an image of a map tile at specified coordinates.
-    tile_fetcher: TileFetcher<'a>,
+    tile_fetcher: IndividualTileFetcher<'a>,
 
     /// Size of the image returned by the [`tile_fetcher`](Self::tile_fetcher).
     tile_size: u32,


### PR DESCRIPTION
## Description

Extends `TileFetcher` to have a `BatchTileFetcher` variant that can fetch all tiles in one function call. Extends the freedom allowed within the tile fetching interface.
