### PR TITLE
Implement `__repr__` method for `geo` wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 authors = ["c1m50c <58411864+c1m50c@users.noreply.github.com>"]
 license = "MIT"
-version = "0.4.3"
+version = "0.4.4"
 
 [workspace.dependencies]
 anyhow = "1.0.89"


### PR DESCRIPTION
## Description

Implements a proper `__repr__` method for all `geo` wrapp types in `snapr-py`.
