### PR TITLE
Stateful Tile Fetching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "examples/batch",
     "examples/label",
     "examples/open-street-maps",
+    "examples/stateful",
     "examples/svg",
     "snapr",
     "snapr-py",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 authors = ["c1m50c <58411864+c1m50c@users.noreply.github.com>"]
 license = "MIT"
-version = "0.4.6"
+version = "0.5.0"
 
 [workspace.dependencies]
 anyhow = "1.0.89"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Snapr ([/ˈsnæp ər/](http://ipa-reader.xyz/?text=%CB%88sn%C3%A6p:%C9%99r)) is 
 - [Labels](./examples/label/) - Example showing how to label a point geometry.
 - [SVGs](./examples/svg/) - Example showing how to draw an SVG on top of a point geometry.
 - [Batch](./examples/batch/) - Example showing how to use a [`TileFetcher::Batch`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Batch), as opposed to the usual [`TileFetcher::Individual`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Individual) variant.
+- [Stateful](./examples/stateful/) - Example showing how to implement the `IndividualTileFetcher` trait to enable a `TileFetcher` that keeps track of state.
 
 ### snapr.py
 

--- a/examples/stateful/Cargo.toml
+++ b/examples/stateful/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stateful"
+edition = "2021"
+publish = false
+
+# Shared Package Configuration
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+geo = { workspace = true }
+image = { workspace = true }
+reqwest = { version = "0.12.7", features = ["blocking"] }
+snapr = { path = "../../snapr" }

--- a/examples/stateful/README.md
+++ b/examples/stateful/README.md
@@ -7,3 +7,6 @@ Example showing how to implement the `IndividualTileFetcher` trait to enable a `
 ```shell
 cargo run --package "stateful"
 ```
+## Output
+
+![Example Output](https://github.com/user-attachments/assets/86c8fd68-36a8-4627-a21e-bcb615e2ca16)

--- a/examples/stateful/README.md
+++ b/examples/stateful/README.md
@@ -1,0 +1,9 @@
+# Stateful
+
+Example showing how to implement the `IndividualTileFetcher` trait to enable a `TileFetcher` that keeps track of state.
+
+## Running
+
+```shell
+cargo run --package "stateful"
+```

--- a/examples/stateful/src/main.rs
+++ b/examples/stateful/src/main.rs
@@ -1,0 +1,60 @@
+use std::io::Cursor;
+
+use image::{DynamicImage, ImageFormat, ImageReader};
+use reqwest::blocking::{Client, ClientBuilder};
+use snapr::{fetchers::IndividualTileFetcher, SnaprBuilder, TileFetcher};
+
+fn main() -> Result<(), anyhow::Error> {
+    let tile_fetcher = OSMTileFetcher::new()?;
+
+    let snapr = SnaprBuilder::new()
+        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_size(256)
+        .with_zoom(15)
+        .build()?;
+
+    let geometry = geo::point!(x: 40.807997, y: -96.699724);
+
+    snapr
+        .generate_snapshot_from_geometry(geometry, &[])?
+        .save("example.png")?;
+
+    Ok(())
+}
+
+struct OSMTileFetcher(Client);
+
+impl OSMTileFetcher {
+    fn new() -> Result<Self, anyhow::Error> {
+        let user_agent = format!("snapr/{version}", version = env!("CARGO_PKG_VERSION"));
+
+        let client = ClientBuilder::new()
+            .user_agent(&user_agent)
+            .build()
+            .map_err(anyhow::Error::from)?;
+
+        Ok(Self(client))
+    }
+}
+
+impl IndividualTileFetcher for OSMTileFetcher {
+    fn fetch_tile(&self, x: i32, y: i32, zoom: u8) -> Result<DynamicImage, snapr::Error> {
+        let address = format!("https://a.tile.osm.org/{zoom}/{x}/{y}.png");
+
+        let cursor = self
+            .0
+            .get(&address)
+            .send()
+            .and_then(|response| response.error_for_status())
+            .and_then(|response| response.bytes())
+            .map(Cursor::new)
+            .map_err(anyhow::Error::from)?;
+
+        let mut image_reader = ImageReader::new(cursor);
+        image_reader.set_format(ImageFormat::Png);
+
+        let image = image_reader.decode().map_err(anyhow::Error::from)?;
+
+        Ok(image)
+    }
+}

--- a/snapr/src/fetchers.rs
+++ b/snapr/src/fetchers.rs
@@ -110,7 +110,7 @@ where
 ///
 /// ```rust
 /// use image::DynamicImage;
-/// use snapr::Error;
+/// use snapr::{Error, TileFetcher};
 ///
 /// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
 ///     todo!()

--- a/snapr/src/fetchers.rs
+++ b/snapr/src/fetchers.rs
@@ -1,0 +1,127 @@
+//! Module containing definitions and implementations for tile fetching traits.
+//! See [`TileFetcher`] for more details.
+
+use image::DynamicImage;
+
+use crate::Error;
+
+/// Types that represent objects that can fetch map tiles one-by-one with the tile's [`EPSG:3857`](https://epsg.io/3857) position.
+///
+/// ## Example
+///
+/// ```rust
+/// use image::DynamicImage;
+/// use snapr::Error;
+///
+/// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
+///     let image = todo!("fetch tile's image from a tile provider");
+///     Ok(image)
+/// }
+/// ```
+#[cfg(feature = "rayon")]
+pub trait IndividualTileFetcher: Sync {
+    /// Takes in a [`EPSG:3857`](https://epsg.io/3857) coordinate and a `zoom` level, and returns an [`Image`](DynamicImage) of the tile at the given position.
+    fn fetch_tile(&self, x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error>;
+}
+
+/// Types that represent objects that can fetch map tiles one-by-one with the tile's [`EPSG:3857`](https://epsg.io/3857) position.
+///
+/// ## Example
+///
+/// ```rust
+/// use image::DynamicImage;
+/// use snapr::Error;
+///
+/// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
+///     let image = todo!("fetch tile's image from a tile provider");
+///     Ok(image)
+/// }
+/// ```
+#[cfg(not(feature = "rayon"))]
+pub trait IndividualTileFetcher {
+    /// Takes in a [`EPSG:3857`](https://epsg.io/3857) coordinate and a `zoom` level, and returns an [`Image`](DynamicImage) of the tile at the given position.
+    fn fetch_tile(&self, x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error>;
+}
+
+#[cfg(feature = "rayon")]
+impl<F> IndividualTileFetcher for F
+where
+    F: Fn(i32, i32, u8) -> Result<DynamicImage, Error> + Sync,
+{
+    fn fetch_tile(&self, x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
+        (self)(x, y, zoom)
+    }
+}
+
+#[cfg(not(feature = "rayon"))]
+impl<F> IndividualTileFetcher for F
+where
+    F: Fn(i32, i32, u8) -> Result<DynamicImage, Error>,
+{
+    fn fetch_tile(&self, x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
+        (self)(x, y, zoom)
+    }
+}
+
+/// Types that represent objects that can fetch map tiles all at once with each tile's [`EPSG:3857`](https://epsg.io/3857) position.
+///
+/// ## Example
+///
+/// ```rust
+/// use image::DynamicImage;
+/// use snapr::Error;
+///
+/// fn tile_fetcher(coordinate_matrix: &[(i32, i32)], zoom: u8) -> Result<Vec<(i32, i32, DynamicImage)>, Error> {
+///     let mut tiles = Vec::new();
+///
+///     for &(x, y) in coordinate_matrix {
+///         let image = todo!("fetch tile's image from a tile provider");
+///         tiles.push((x, y, image));
+///     }
+///
+///     Ok(tiles)
+/// }
+/// ```
+pub trait BatchTileFetcher {
+    /// Takes in a matrix of [`EPSG:3857`](https://epsg.io/3857) coordinates and a `zoom` level, and returns a [`Vec`] of each tile's position and [`Image`](DynamicImage).
+    fn fetch_tiles(
+        &self,
+        coordinate_matrix: &[(i32, i32)],
+        zoom: u8,
+    ) -> Result<Vec<(i32, i32, DynamicImage)>, Error>;
+}
+
+impl<F> BatchTileFetcher for F
+where
+    F: Fn(&[(i32, i32)], u8) -> Result<Vec<(i32, i32, DynamicImage)>, Error>,
+{
+    fn fetch_tiles(
+        &self,
+        coordinate_matrix: &[(i32, i32)],
+        zoom: u8,
+    ) -> Result<Vec<(i32, i32, DynamicImage)>, Error> {
+        (self)(coordinate_matrix, zoom)
+    }
+}
+
+/// Represents types implementing either [`IndividualTileFetcher`] or [`BatchTileFetcher`].
+///
+/// ## Example
+///
+/// ```rust
+/// use image::DynamicImage;
+/// use snapr::Error;
+///
+/// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
+///     todo!()
+/// }
+///
+/// let individual_tile_fetcher = TileFetcher::Individual(&tile_fetcher);
+/// ```
+pub enum TileFetcher<'a> {
+    /// See [`IndividualTileFetcher`].
+    Individual(&'a dyn IndividualTileFetcher),
+
+    /// See [`BatchTileFetcher`].
+    Batch(&'a dyn BatchTileFetcher),
+}


### PR DESCRIPTION
## Description

Resolves #13 by enabling stateful tile fetching via splitting out `BatchTileFetcher` and `IndividualTileFetcher` into traits. AFAIK, this shouldn't break any existing code, due to the following `impl` blocks:

```rust
impl<F> BatchTileFetcher for F
where
    F: Fn(&[(i32, i32)], u8) -> Result<Vec<(i32, i32, DynamicImage)>, Error>,
{
    fn fetch_tiles(
        &self,
        coordinate_matrix: &[(i32, i32)],
        zoom: u8,
    ) -> Result<Vec<(i32, i32, DynamicImage)>, Error> {
        (self)(coordinate_matrix, zoom)
    }
}
```

```rust
impl<F> IndividualTileFetcher for F
where
    F: Fn(i32, i32, u8) -> Result<DynamicImage, Error>,
{
    fn fetch_tile(&self, x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
        (self)(x, y, zoom)
    }
}
```
