### PR TITLE
Dynamic `Effect` Functions

### DIFF
--- a/examples/label/src/main.rs
+++ b/examples/label/src/main.rs
@@ -6,7 +6,7 @@ use reqwest::blocking::ClientBuilder;
 use snapr::{
     drawing::{
         geometry::{line::LineStringStyle, point::PointStyle},
-        style::{ColorOptions, Styleable},
+        style::{ColorOptions, Effect, Styleable},
         svg::Label,
     },
     SnaprBuilder, TileFetcher,
@@ -27,7 +27,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let geometry = line_string.as_styled(LineStringStyle {
         point_style: PointStyle {
-            effect: Some(|style, _, context| PointStyle {
+            effect: Some(Effect::new(|style, _, context| PointStyle {
                 label: Some(Label {
                     color_options: ColorOptions {
                         border: Some(1.25),
@@ -37,7 +37,7 @@ fn main() -> Result<(), anyhow::Error> {
                     ..Default::default()
                 }),
                 ..style
-            }),
+            })),
             ..Default::default()
         },
         ..Default::default()

--- a/snapr/src/drawing/geometry/line.rs
+++ b/snapr/src/drawing/geometry/line.rs
@@ -61,7 +61,7 @@ impl_styled_geo!(
             Some(effect) => {
                 &(effect
                     .clone()
-                    .apply(self.style.clone(), &self.inner, context))
+                    .apply(self.style.clone(), self.inner, context))
             }
 
             None => &self.style,
@@ -145,7 +145,7 @@ impl_styled_geo!(
             Some(effect) => {
                 &(effect
                     .clone()
-                    .apply(self.style.clone(), &self.inner, context))
+                    .apply(self.style.clone(), self.inner, context))
             }
 
             None => &self.style,

--- a/snapr/src/drawing/geometry/line.rs
+++ b/snapr/src/drawing/geometry/line.rs
@@ -1,5 +1,7 @@
 //! Contains [`Drawable`] implementations and [`Styles`](Style) for [`geo::Line`], and [`geo::LineString`] primitives.
 
+use std::fmt;
+
 use geo::MapCoords;
 use tiny_skia::{Color, Paint, PathBuilder, Pixmap, Shader, Stroke, Transform};
 
@@ -12,16 +14,26 @@ use super::{macros::impl_styled_geo, point::PointStyle};
 
 macro_rules! impl_line_style {
     ($style: ident, $line: ident) => {
-        #[derive(Clone, Debug, PartialEq)]
+        #[derive(Clone)]
         #[doc = concat!("A style that can be applied to the [`geo::", stringify!($line), "`] primitive.")]
-        pub struct $style {
+        pub struct $style<'a> {
             pub color_options: ColorOptions,
-            pub point_style: PointStyle,
+            pub point_style: PointStyle<'a>,
             pub width: f32,
-            pub effect: Option<Effect<geo::$line<f64>, Self>>,
+            pub effect: Option<Effect<'a, geo::$line<f64>, Self>>,
         }
 
-        impl Default for $style {
+        impl<'a> fmt::Debug for $style<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($style))
+                    .field("color_options", &self.color_options)
+                    .field("point_style", &self.point_style)
+                    .field("width", &self.width)
+                    .finish()
+            }
+        }
+
+        impl<'a> Default for $style<'a> {
             fn default() -> Self {
                 Self {
                     color_options: ColorOptions {
@@ -43,10 +55,15 @@ impl_line_style!(LineStringStyle, LineString);
 
 impl_styled_geo!(
     Line,
-    LineStyle,
+    LineStyle<'_>,
     fn draw(&self, pixmap: &mut Pixmap, context: &Context) -> Result<(), crate::Error> {
-        let style = match self.style.effect {
-            Some(effect) => &((effect)(self.style.clone(), self.inner, context)),
+        let style = match &self.style.effect {
+            Some(effect) => {
+                &(effect
+                    .clone()
+                    .apply(self.style.clone(), &self.inner, context))
+            }
+
             None => &self.style,
         };
 
@@ -122,10 +139,15 @@ impl_styled_geo!(
 
 impl_styled_geo!(
     LineString,
-    LineStringStyle,
+    LineStringStyle<'_>,
     fn draw(&self, pixmap: &mut Pixmap, context: &Context) -> Result<(), crate::Error> {
-        let style = match self.style.effect {
-            Some(effect) => &((effect)(self.style.clone(), self.inner, context)),
+        let style = match &self.style.effect {
+            Some(effect) => {
+                &(effect
+                    .clone()
+                    .apply(self.style.clone(), &self.inner, context))
+            }
+
             None => &self.style,
         };
 
@@ -197,7 +219,7 @@ impl_styled_geo!(
 
 impl_styled_geo!(
     MultiLineString,
-    LineStringStyle,
+    LineStringStyle<'_>,
     fn draw(&self, pixmap: &mut Pixmap, context: &Context) -> Result<(), crate::Error> {
         self.inner
             .iter()

--- a/snapr/src/drawing/geometry/point.rs
+++ b/snapr/src/drawing/geometry/point.rs
@@ -83,7 +83,7 @@ impl_styled_geo!(
             Some(effect) => {
                 &(effect
                     .clone()
-                    .apply(self.style.clone(), &self.inner, context))
+                    .apply(self.style.clone(), self.inner, context))
             }
 
             None => &self.style,

--- a/snapr/src/drawing/geometry/polygon.rs
+++ b/snapr/src/drawing/geometry/polygon.rs
@@ -54,7 +54,7 @@ impl_styled_geo!(
             Some(effect) => {
                 &(effect
                     .clone()
-                    .apply(self.style.clone(), &self.inner, context))
+                    .apply(self.style.clone(), self.inner, context))
             }
 
             None => &self.style,

--- a/snapr/src/drawing/style.rs
+++ b/snapr/src/drawing/style.rs
@@ -24,6 +24,7 @@ pub trait Styleable<S>: Drawable + Sized {
 /// Used by styles to enable more dynamic _effects_ on said styles.
 #[derive(Clone)]
 pub struct Effect<'a, T: Drawable, S> {
+    #[allow(clippy::type_complexity)]
     func: Rc<dyn (Fn(S, &T, &Context) -> S) + 'a>,
 }
 


### PR DESCRIPTION
## Description

Makes the `Effect` field of styles hold a dynamic function pointer instead of a primitive to enable out-of-scope variable capturing inside the `Effect` functions.
