### PR TITLE
Boxed `TileFetcher` Variants

### DIFF
--- a/examples/batch/src/main.rs
+++ b/examples/batch/src/main.rs
@@ -6,7 +6,7 @@ use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Batch(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::batch(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/label/src/main.rs
+++ b/examples/label/src/main.rs
@@ -14,7 +14,7 @@ use snapr::{
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(16)
         .build()?;

--- a/examples/open-street-maps/src/line/main.rs
+++ b/examples/open-street-maps/src/line/main.rs
@@ -3,7 +3,7 @@ use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/line_string/main.rs
+++ b/examples/open-street-maps/src/line_string/main.rs
@@ -4,7 +4,7 @@ use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/point/main.rs
+++ b/examples/open-street-maps/src/point/main.rs
@@ -3,7 +3,7 @@ use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/open-street-maps/src/polygon/main.rs
+++ b/examples/open-street-maps/src/polygon/main.rs
@@ -4,7 +4,7 @@ use snapr::{SnaprBuilder, TileFetcher};
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/stateful/src/main.rs
+++ b/examples/stateful/src/main.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), anyhow::Error> {
     let tile_fetcher = OSMTileFetcher::new()?;
 
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -36,7 +36,7 @@ const SVG: &str = r##"
 
 fn main() -> Result<(), anyhow::Error> {
     let snapr = SnaprBuilder::new()
-        .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+        .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
         .with_tile_size(256)
         .with_zoom(15)
         .build()?;

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -15,7 +15,7 @@ use crate::{Error, Snapr, TileFetcher, Zoom};
 /// }
 ///
 /// let snapr = SnaprBuilder::new()
-///     .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+///     .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
 ///     .build();
 ///
 /// assert!(snapr.is_ok());
@@ -88,7 +88,7 @@ impl<'a> SnaprBuilder<'a> {
     /// }
     ///
     /// let snapr = SnaprBuilder::new()
-    ///     .with_tile_fetcher(TileFetcher::Individual(&tile_fetcher))
+    ///     .with_tile_fetcher(TileFetcher::individual(tile_fetcher))
     ///     .build();
     ///
     /// assert!(snapr.is_ok());

--- a/snapr/src/fetchers.rs
+++ b/snapr/src/fetchers.rs
@@ -116,12 +116,56 @@ where
 ///     todo!()
 /// }
 ///
-/// let individual_tile_fetcher = TileFetcher::Individual(&tile_fetcher);
+/// let individual_tile_fetcher = TileFetcher::individual(tile_fetcher);
 /// ```
 pub enum TileFetcher<'a> {
     /// See [`IndividualTileFetcher`].
-    Individual(&'a dyn IndividualTileFetcher),
+    Individual(Box<dyn IndividualTileFetcher + 'a>),
 
     /// See [`BatchTileFetcher`].
-    Batch(&'a dyn BatchTileFetcher),
+    Batch(Box<dyn BatchTileFetcher + 'a>),
+}
+
+impl<'a> TileFetcher<'a> {
+    /// Constructs a new [`TileFetcher::Individual`] from a [`IndividualTileFetcher`].
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use image::DynamicImage;
+    /// use snapr::{Error, TileFetcher};
+    ///
+    /// fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, Error> {
+    ///     todo!()
+    /// }
+    ///
+    /// let fetcher = TileFetcher::individual(tile_fetcher);
+    /// ```
+    pub fn individual<F>(tile_fetcher: F) -> Self
+    where
+        F: IndividualTileFetcher + 'a,
+    {
+        TileFetcher::Individual(Box::new(tile_fetcher))
+    }
+
+    /// Constructs a new [`TileFetcher::Batch`] from a [`BatchTileFetcher`].
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use image::DynamicImage;
+    /// use snapr::{Error, TileFetcher};
+    ///
+    /// fn tile_fetcher(coordinate_matrix: &[(i32, i32)], zoom: u8) -> Result<Vec<(i32, i32, DynamicImage)>, Error>{
+    ///     todo!()
+    /// }
+    ///
+    /// let fetcher = TileFetcher::batch(tile_fetcher);
+    /// ```
+    pub fn batch<F>(tile_fetcher: F) -> Self
+    where
+        F: BatchTileFetcher + 'a,
+    {
+        Self::Batch(Box::new(tile_fetcher))
+    }
 }

--- a/snapr/src/fetchers.rs
+++ b/snapr/src/fetchers.rs
@@ -141,6 +141,7 @@ impl<'a> TileFetcher<'a> {
     ///
     /// let fetcher = TileFetcher::individual(tile_fetcher);
     /// ```
+    #[inline(always)]
     pub fn individual<F>(tile_fetcher: F) -> Self
     where
         F: IndividualTileFetcher + 'a,
@@ -162,6 +163,7 @@ impl<'a> TileFetcher<'a> {
     ///
     /// let fetcher = TileFetcher::batch(tile_fetcher);
     /// ```
+    #[inline(always)]
     pub fn batch<F>(tile_fetcher: F) -> Self
     where
         F: BatchTileFetcher + 'a,

--- a/snapr/src/lib.rs
+++ b/snapr/src/lib.rs
@@ -277,7 +277,7 @@ impl<'a> Snapr<'a> {
             .flat_map(|(x, y)| y.map(move |y| (x, y)));
 
         match self.tile_fetcher {
-            TileFetcher::Individual(tile_fetcher) => {
+            TileFetcher::Individual(ref tile_fetcher) => {
                 // Capture various fields in `self` to enable `x_y_to_tile` to automatically implement `Sync`
                 let (tile_fetcher, tile_size, height, width, zoom) =
                     (tile_fetcher, self.tile_size, self.height, self.width, zoom);
@@ -317,7 +317,7 @@ impl<'a> Snapr<'a> {
                 }
             }
 
-            TileFetcher::Batch(tile_fetcher) => {
+            TileFetcher::Batch(ref tile_fetcher) => {
                 let coordinate_matrix = coordinate_matrix.collect::<Vec<_>>();
 
                 for (x, y, tile) in tile_fetcher.fetch_tiles(&coordinate_matrix, zoom)? {


### PR DESCRIPTION
## Description

Converts the inner `TileFetcher` variants to use `Box` pointers instead of references. I am primarily doing this so you can create a `TileFetcher` inside a function and return it from it; among other reasons.
