### PR TITLE
Asynchronous Tile Fetchin'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "examples/open-street-maps",
     "examples/stateful",
     "examples/svg",
+    "examples/tokio",
     "snapr",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Snapr ([/ˈsnæp ər/](http://ipa-reader.xyz/?text=%CB%88sn%C3%A6p:%C9%99r)) is 
 - [SVGs](./examples/svg/) - Example showing how to draw an SVG on top of a point geometry.
 - [Batch](./examples/batch/) - Example showing how to use a [`TileFetcher::Batch`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Batch), as opposed to the usual [`TileFetcher::Individual`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Individual) variant.
 - [Stateful](./examples/stateful/) - Example showing how to implement the `IndividualTileFetcher` trait to enable a `TileFetcher` that keeps track of state.
+- [Tokio](./examples/tokio/) - Example showing how to use the `tokio` feature flag to build an asynchronous `TileFetcher`.
 
 ## License
 

--- a/examples/tokio/Cargo.toml
+++ b/examples/tokio/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "async-tokio"
+edition = "2021"
+publish = false
+
+# Shared Package Configuration
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+geo = { workspace = true }
+image = { workspace = true }
+reqwest = { version = "0.12.7" }
+snapr = { path = "../../snapr", features = ["tokio"] }
+tiny-skia = { workspace = true }
+tokio = { version = "1.41.0", features = ["full"] }

--- a/examples/tokio/README.md
+++ b/examples/tokio/README.md
@@ -1,0 +1,9 @@
+# Tokio
+
+Example showing how to use the `tokio` feature flag to build an asynchronous `TileFetcher`.
+
+## Running
+
+```shell
+cargo run --package "async-tokio"
+```

--- a/examples/tokio/src/main.rs
+++ b/examples/tokio/src/main.rs
@@ -1,0 +1,50 @@
+use std::io::Cursor;
+
+use image::{DynamicImage, ImageFormat, ImageReader};
+use reqwest::ClientBuilder;
+use snapr::{fetchers::AsyncTileFetcher, tokio::SnaprBuilder};
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let snapr = SnaprBuilder::new()
+        .with_tile_fetcher(AsyncTileFetcher::individual(tile_fetcher))
+        .with_tile_size(256)
+        .with_zoom(16)
+        .build()
+        .await?;
+
+    let geometry = geo::point!(x: 41.11839, y: -95.91013);
+
+    snapr
+        .snapshot_from_geometry(geometry)?
+        .save("example.png")?;
+
+    Ok(())
+}
+
+async fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, snapr::Error> {
+    let address = format!("https://a.tile.osm.org/{zoom}/{x}/{y}.png");
+
+    let client = ClientBuilder::new()
+        .user_agent("snapr / 0.1.0")
+        .build()
+        .map_err(anyhow::Error::from)?;
+
+    let cursor = client
+        .get(address)
+        .send()
+        .await
+        .and_then(|response| response.error_for_status())
+        .map_err(anyhow::Error::from)?
+        .bytes()
+        .await
+        .map(Cursor::new)
+        .map_err(anyhow::Error::from)?;
+
+    let mut image_reader = ImageReader::new(cursor);
+    image_reader.set_format(ImageFormat::Png);
+
+    let image = image_reader.decode().map_err(anyhow::Error::from)?;
+
+    Ok(image)
+}

--- a/snapr/Cargo.toml
+++ b/snapr/Cargo.toml
@@ -15,9 +15,11 @@ version.workspace = true
 default = ["rayon", "svg"]
 rayon = ["dep:rayon"]
 svg = ["dep:resvg"]
+tokio = ["dep:async-trait", "dep:tokio"]
 
 [dependencies]
 anyhow.workspace = true
+async-trait = { version = "0.1.83", optional = true }
 geo.workspace = true
 hex = { workspace = true }
 image.workspace = true
@@ -25,3 +27,4 @@ rayon = { workspace = true, optional = true }
 resvg = { workspace = true, optional = true }
 thiserror.workspace = true
 tiny-skia = { workspace = true }
+tokio = { version = "1.41.0", optional = true, features = ["rt"] }

--- a/snapr/README.md
+++ b/snapr/README.md
@@ -8,15 +8,16 @@ Snapr ([/ˈsnæp ər/](http://ipa-reader.xyz/?text=%CB%88sn%C3%A6p:%C9%99r)) is 
 
 ## Examples
 
-- [Open Street Maps](https://github.com/c1m50c/snapr/blob/main/examples/open-street-maps/) - Collection of binaries using an OSM tile fetcher.
-  - [Point](https://github.com/c1m50c/snapr/blob/main/examples/open-street-maps/src/point/) - Example showing how to draw a point geometry.
-  - [Line](https://github.com/c1m50c/snapr/blob/main/examples/open-street-maps/src/line/) - Example showing how to draw a line geometry.
-  - [Line String](https://github.com/c1m50c/snapr/blob/main/examples/open-street-maps/src/line_string/) - Example showing how to draw a line string geometry.
-  - [Polygon](https://github.com/c1m50c/snapr/blob/main/examples/open-street-maps/src/polygon/) - Example showing how to draw a polygon geometry.
-- [Labels](https://github.com/c1m50c/snapr/blob/main/examples/label/) - Example showing how to label a point geometry.
-- [SVG](https://github.com/c1m50c/snapr/blob/main/examples/svg/) - Example showing how to draw an SVG on top of a point geometry.
-- [Batch](https://github.com/c1m50c/snapr/blob/main/examples/batch/) - Example showing how to use a [`TileFetcher::Batch`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Batch), as opposed to the usual [`TileFetcher::Individual`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Individual) variant.
+- [Open Street Maps](./examples/open-street-maps/) - Collection of binaries using an OSM tile fetcher.
+  - [Point](./examples/open-street-maps/src/point/) - Example showing how to draw a point geometry.
+  - [Line](./examples/open-street-maps/src/line/) - Example showing how to draw a line geometry.
+  - [Line String](./examples/open-street-maps/src/line_string/) - Example showing how to draw a line string geometry.
+  - [Polygon](./examples/open-street-maps/src/polygon/) - Example showing how to draw a polygon geometry.
+- [Labels](./examples/label/) - Example showing how to label a point geometry.
+- [SVGs](./examples/svg/) - Example showing how to draw an SVG on top of a point geometry.
+- [Batch](./examples/batch/) - Example showing how to use a [`TileFetcher::Batch`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Batch), as opposed to the usual [`TileFetcher::Individual`](https://docs.rs/snapr/latest/snapr/enum.TileFetcher.html#variant.Individual) variant.
 - [Stateful](./examples/stateful/) - Example showing how to implement the `IndividualTileFetcher` trait to enable a `TileFetcher` that keeps track of state.
+- [Tokio](./examples/tokio/) - Example showing how to use the `tokio` feature flag to build an asynchronous `TileFetcher`.
 
 ## License
 

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -6,22 +6,22 @@ use crate::{Error, Snapr, TileFetcher, Zoom};
 
 pub(crate) mod macros {
     macro_rules! impl_snapr_builder {
-        ($builder: ty, $snapr: ty, $tile_fetcher: ty) => {
-            impl<'a> $builder {
-                #[doc = concat!("Constructs a new [`", stringify!($builder), "`] to be used in constructing a [`", stringify!($snapr), "`].")]
+        (($builder_ty: ty, $builder_ident: ident), ($snapr_ty: ty, $snapr_ident: ident), ($tile_fetcher_ty: ty, $tile_fetcher_ident: ident)) => {
+            impl<'a> $builder_ty {
+                #[doc = concat!("Constructs a new [`", stringify!($builder_ident), "`] to be used in constructing a [`", stringify!($snapr_ident), "`].")]
                 pub fn new() -> Self {
                     Self::default()
                 }
 
-                #[doc = concat!("Configures a [`", stringify!($tile_fetcher), "`] to be used in the [`", stringify!($snapr), "::tile_fetcher`] field.")]
-                pub fn with_tile_fetcher(self, tile_fetcher: $tile_fetcher) -> Self {
+                #[doc = concat!("Configures a [`", stringify!($tile_fetcher_ident), "`] to be used in the [`", stringify!($snapr_ident), "::tile_fetcher`] field.")]
+                pub fn with_tile_fetcher(self, tile_fetcher: $tile_fetcher_ty) -> Self {
                     Self {
                         tile_fetcher: Some(tile_fetcher),
                         ..self
                     }
                 }
 
-                #[doc = concat!("Configures the `tile_size` to be used in the [`", stringify!($snapr), "::tile_size`] field.")]
+                #[doc = concat!("Configures the `tile_size` to be used in the [`", stringify!($snapr_ident), "::tile_size`] field.")]
                 pub fn with_tile_size(self, tile_size: u32) -> Self {
                     Self {
                         tile_size: Some(tile_size),
@@ -29,7 +29,7 @@ pub(crate) mod macros {
                     }
                 }
 
-                #[doc = concat!("Configures the `height` to be used in the [`", stringify!($snapr), "::height`] field.")]
+                #[doc = concat!("Configures the `height` to be used in the [`", stringify!($snapr_ident), "::height`] field.")]
                 pub fn with_height(self, height: u32) -> Self {
                     Self {
                         height: Some(height),
@@ -37,7 +37,7 @@ pub(crate) mod macros {
                     }
                 }
 
-                #[doc = concat!("Configures the `width` to be used in the [`", stringify!($snapr), "::width`] field.")]
+                #[doc = concat!("Configures the `width` to be used in the [`", stringify!($snapr_ident), "::width`] field.")]
                 pub fn with_width(self, width: u32) -> Self {
                     Self {
                         width: Some(width),
@@ -45,7 +45,7 @@ pub(crate) mod macros {
                     }
                 }
 
-                #[doc = concat!("Configures the `zoom` to be used in the [`", stringify!($snapr), "::zoom`] field.")]
+                #[doc = concat!("Configures the `zoom` to be used in the [`", stringify!($snapr_ident), "::zoom`] field.")]
                 pub fn with_zoom<Z: Into<Zoom>>(self, zoom: Z) -> Self {
                     Self {
                         zoom: Some(zoom.into()),
@@ -59,7 +59,7 @@ pub(crate) mod macros {
     pub(crate) use impl_snapr_builder;
 }
 
-/// Builder structure for [`snapr`].
+/// Builder structure for [`Snapr`].
 ///
 /// ## Example
 ///
@@ -130,7 +130,11 @@ impl<'a> SnaprBuilder<'a> {
     }
 }
 
-impl_snapr_builder!(SnaprBuilder<'a>, Snapr<'a>, TileFetcher<'a>);
+impl_snapr_builder!(
+    (SnaprBuilder<'a>, SnaprBuilder),
+    (Snapr<'a>, Snapr),
+    (TileFetcher<'a>, TileFetcher)
+);
 
 impl<'a> fmt::Debug for SnaprBuilder<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/snapr/src/builder.rs
+++ b/snapr/src/builder.rs
@@ -1,6 +1,63 @@
 use std::fmt;
 
+use macros::impl_snapr_builder;
+
 use crate::{Error, Snapr, TileFetcher, Zoom};
+
+pub(crate) mod macros {
+    macro_rules! impl_snapr_builder {
+        ($builder: ty, $snapr: ty, $tile_fetcher: ty) => {
+            impl<'a> $builder {
+                #[doc = concat!("Constructs a new [`", stringify!($builder), "`] to be used in constructing a [`", stringify!($snapr), "`].")]
+                pub fn new() -> Self {
+                    Self::default()
+                }
+
+                #[doc = concat!("Configures a [`", stringify!($tile_fetcher), "`] to be used in the [`", stringify!($snapr), "::tile_fetcher`] field.")]
+                pub fn with_tile_fetcher(self, tile_fetcher: $tile_fetcher) -> Self {
+                    Self {
+                        tile_fetcher: Some(tile_fetcher),
+                        ..self
+                    }
+                }
+
+                #[doc = concat!("Configures the `tile_size` to be used in the [`", stringify!($snapr), "::tile_size`] field.")]
+                pub fn with_tile_size(self, tile_size: u32) -> Self {
+                    Self {
+                        tile_size: Some(tile_size),
+                        ..self
+                    }
+                }
+
+                #[doc = concat!("Configures the `height` to be used in the [`", stringify!($snapr), "::height`] field.")]
+                pub fn with_height(self, height: u32) -> Self {
+                    Self {
+                        height: Some(height),
+                        ..self
+                    }
+                }
+
+                #[doc = concat!("Configures the `width` to be used in the [`", stringify!($snapr), "::width`] field.")]
+                pub fn with_width(self, width: u32) -> Self {
+                    Self {
+                        width: Some(width),
+                        ..self
+                    }
+                }
+
+                #[doc = concat!("Configures the `zoom` to be used in the [`", stringify!($snapr), "::zoom`] field.")]
+                pub fn with_zoom<Z: Into<Zoom>>(self, zoom: Z) -> Self {
+                    Self {
+                        zoom: Some(zoom.into()),
+                        ..self
+                    }
+                }
+            }
+        };
+    }
+
+    pub(crate) use impl_snapr_builder;
+}
 
 /// Builder structure for [`snapr`].
 ///
@@ -30,51 +87,6 @@ pub struct SnaprBuilder<'a> {
 }
 
 impl<'a> SnaprBuilder<'a> {
-    /// Constructs a new [`SnaprBuilder`] to be used in constructing a [`Snapr`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Configures a [`TileFetcher`] to be used in the [`Snapr::tile_fetcher`] field.
-    pub fn with_tile_fetcher(self, tile_fetcher: TileFetcher<'a>) -> Self {
-        Self {
-            tile_fetcher: Some(tile_fetcher),
-            ..self
-        }
-    }
-
-    /// Configures the `tile_size` to be used in the [`Snapr::tile_size`] field.
-    pub fn with_tile_size(self, tile_size: u32) -> Self {
-        Self {
-            tile_size: Some(tile_size),
-            ..self
-        }
-    }
-
-    /// Configures the `height` to be used in the [`Snapr::height`] field.
-    pub fn with_height(self, height: u32) -> Self {
-        Self {
-            height: Some(height),
-            ..self
-        }
-    }
-
-    /// Configures the `width` to be used in the [`Snapr::width`] field.
-    pub fn with_width(self, width: u32) -> Self {
-        Self {
-            width: Some(width),
-            ..self
-        }
-    }
-
-    /// Configures the `zoom` to be used in the [`Snapr::zoom`] field.
-    pub fn with_zoom<Z: Into<Zoom>>(self, zoom: Z) -> Self {
-        Self {
-            zoom: Some(zoom.into()),
-            ..self
-        }
-    }
-
     /// Attempts to construct a new [`Snapr`] from the [`SnaprBuilder`].
     ///
     /// ## Example
@@ -117,6 +129,8 @@ impl<'a> SnaprBuilder<'a> {
         Ok(snapr)
     }
 }
+
+impl_snapr_builder!(SnaprBuilder<'a>, Snapr<'a>, TileFetcher<'a>);
 
 impl<'a> fmt::Debug for SnaprBuilder<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/snapr/src/lib.rs
+++ b/snapr/src/lib.rs
@@ -51,9 +51,13 @@ pub enum Error {
     #[error("failed to calculate a centroid for the geometry collection")]
     CentroidCalculation,
 
+    #[cfg(feature = "tokio")]
+    #[error("inner panic of spawned asynchronous task")]
+    AsynchronousTaskPanic,
+
     /// Transparent errors returned from [`resvg::usvg`] functions.
-    #[error(transparent)]
     #[cfg(feature = "svg")]
+    #[error(transparent)]
     Usvg(#[from] resvg::usvg::Error),
 
     /// Returned when the source of the error cannot be determined.

--- a/snapr/src/lib.rs
+++ b/snapr/src/lib.rs
@@ -19,6 +19,9 @@ pub use builder::SnaprBuilder;
 pub use fetchers::TileFetcher;
 pub use {geo, image, tiny_skia};
 
+#[cfg(feature = "tokio")]
+pub use fetchers::AsyncTileFetcher;
+
 mod builder;
 pub mod drawing;
 pub mod fetchers;

--- a/snapr/src/lib.rs
+++ b/snapr/src/lib.rs
@@ -23,6 +23,9 @@ mod builder;
 pub mod drawing;
 pub mod fetchers;
 
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
 /// Error type used throughout the [`snapr`](crate) crate.
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/snapr/src/tokio.rs
+++ b/snapr/src/tokio.rs
@@ -1,0 +1,101 @@
+use std::fmt;
+
+use tokio::runtime::Handle;
+
+use crate::{
+    builder::macros::impl_snapr_builder,
+    fetchers::{AsyncTileFetcher, BatchTileFetcher},
+    Error, Snapr, TileFetcher, Zoom,
+};
+
+/// Builder structure for [`Snapr`].
+#[derive(Default)]
+pub struct SnaprBuilder<'a> {
+    tile_fetcher: Option<AsyncTileFetcher<'a>>,
+    tile_size: Option<u32>,
+    height: Option<u32>,
+    width: Option<u32>,
+    zoom: Option<Zoom>,
+}
+
+impl<'a> SnaprBuilder<'a> {
+    /// Attempts to construct a new [`Snapr`] from the [`SnaprBuilder`].
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use image::DynamicImage;
+    /// use snapr::{AsyncTileFetcher, tokio::SnaprBuilder};
+    ///
+    /// async fn tile_fetcher(x: i32, y: i32, zoom: u8) -> Result<DynamicImage, snapr::Error> {
+    ///     todo!()
+    /// }
+    ///
+    /// let snapr = SnaprBuilder::new()
+    ///     .with_tile_fetcher(AsyncTileFetcher::Individual(&tile_fetcher))
+    ///     .build();
+    ///
+    /// assert!(snapr.is_ok());
+    /// ```
+    pub async fn build(self) -> Result<Snapr<'a>, Error> {
+        let Some(tile_fetcher) = self.tile_fetcher else {
+            return Err(Error::Builder {
+                reason: "field `tile_fetcher` needs to be set prior to a `snapr` being built"
+                    .to_string(),
+            });
+        };
+
+        let tile_size = self.tile_size.unwrap_or(256);
+        let height = self.height.unwrap_or(600);
+        let width = self.width.unwrap_or(800);
+        let zoom = self.zoom.unwrap_or_default();
+        let handle = Handle::current();
+
+        let tile_fetcher = {
+            let tokio_tile_fetcher = TokioTileFetcher {
+                inner: tile_fetcher,
+                handle,
+            };
+
+            TileFetcher::Batch(&tokio_tile_fetcher)
+        };
+
+        let snapr = crate::Snapr {
+            tile_fetcher,
+            tile_size,
+            height,
+            width,
+            zoom,
+        };
+
+        Ok(snapr)
+    }
+}
+
+impl_snapr_builder!(SnaprBuilder<'a>, Snapr<'a>, AsyncTileFetcher<'a>);
+
+impl<'a> fmt::Debug for SnaprBuilder<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SnaprBuilder")
+            .field("tile_size", &self.tile_size)
+            .field("height", &self.height)
+            .field("width", &self.width)
+            .field("zoom", &self.zoom)
+            .finish()
+    }
+}
+
+struct TokioTileFetcher<'a> {
+    inner: AsyncTileFetcher<'a>,
+    handle: Handle,
+}
+
+impl<'a> BatchTileFetcher for TokioTileFetcher<'a> {
+    fn fetch_tiles(
+        &self,
+        coordinate_matrix: &[(i32, i32)],
+        zoom: u8,
+    ) -> Result<Vec<(i32, i32, image::DynamicImage)>, Error> {
+        todo!("execute `inner` and return results")
+    }
+}

--- a/snapr/src/tokio.rs
+++ b/snapr/src/tokio.rs
@@ -10,15 +10,15 @@ use crate::{
 
 /// Builder structure for [`Snapr`].
 #[derive(Default)]
-pub struct SnaprBuilder {
-    tile_fetcher: Option<AsyncTileFetcher>,
+pub struct SnaprBuilder<'a> {
+    tile_fetcher: Option<AsyncTileFetcher<'a>>,
     tile_size: Option<u32>,
     height: Option<u32>,
     width: Option<u32>,
     zoom: Option<Zoom>,
 }
 
-impl SnaprBuilder {
+impl<'a> SnaprBuilder<'a> {
     /// Attempts to construct a new [`Snapr`] from the [`SnaprBuilder`].
     ///
     /// ## Example
@@ -31,13 +31,17 @@ impl SnaprBuilder {
     ///     todo!()
     /// }
     ///
-    /// let snapr = SnaprBuilder::new()
-    ///     .with_tile_fetcher(AsyncTileFetcher::individual(tile_fetcher))
-    ///     .build();
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let snapr = SnaprBuilder::new()
+    ///         .with_tile_fetcher(AsyncTileFetcher::individual(tile_fetcher))
+    ///         .build()
+    ///         .await;
     ///
-    /// assert!(snapr.is_ok());
+    ///     assert!(snapr.is_ok());
+    /// }
     /// ```
-    pub async fn build<'a>(self) -> Result<Snapr<'a>, Error> {
+    pub async fn build(self) -> Result<Snapr<'a>, Error> {
         let Some(tile_fetcher) = self.tile_fetcher else {
             return Err(Error::Builder {
                 reason: "field `tile_fetcher` needs to be set prior to a `snapr` being built"
@@ -71,9 +75,9 @@ impl SnaprBuilder {
     }
 }
 
-impl_snapr_builder!(SnaprBuilder, Snapr<'a>, AsyncTileFetcher);
+impl_snapr_builder!(SnaprBuilder<'a>, Snapr<'a>, AsyncTileFetcher<'a>);
 
-impl fmt::Debug for SnaprBuilder {
+impl<'a> fmt::Debug for SnaprBuilder<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SnaprBuilder")
             .field("tile_size", &self.tile_size)
@@ -84,12 +88,12 @@ impl fmt::Debug for SnaprBuilder {
     }
 }
 
-struct TokioTileFetcher {
+struct TokioTileFetcher<'a> {
     handle: Handle,
-    inner: AsyncTileFetcher,
+    inner: AsyncTileFetcher<'a>,
 }
 
-impl BatchTileFetcher for TokioTileFetcher {
+impl<'a> BatchTileFetcher for TokioTileFetcher<'a> {
     fn fetch_tiles(
         &self,
         coordinate_matrix: &[(i32, i32)],

--- a/snapr/src/tokio.rs
+++ b/snapr/src/tokio.rs
@@ -49,15 +49,14 @@ impl<'a> SnaprBuilder<'a> {
         let height = self.height.unwrap_or(600);
         let width = self.width.unwrap_or(800);
         let zoom = self.zoom.unwrap_or_default();
-        let handle = Handle::current();
 
         let tile_fetcher = {
             let tokio_tile_fetcher = TokioTileFetcher {
+                handle: Handle::current(),
                 inner: tile_fetcher,
-                handle,
             };
 
-            TileFetcher::Batch(&tokio_tile_fetcher)
+            TileFetcher::batch(tokio_tile_fetcher)
         };
 
         let snapr = crate::Snapr {
@@ -86,8 +85,8 @@ impl<'a> fmt::Debug for SnaprBuilder<'a> {
 }
 
 struct TokioTileFetcher<'a> {
-    inner: AsyncTileFetcher<'a>,
     handle: Handle,
+    inner: AsyncTileFetcher<'a>,
 }
 
 impl<'a> BatchTileFetcher for TokioTileFetcher<'a> {

--- a/snapr/src/tokio.rs
+++ b/snapr/src/tokio.rs
@@ -1,3 +1,5 @@
+//! Contains a [`SnaprBuilder`] implementation that constructs an [`AsyncTileFetcher`] with a [`tokio`] executor.
+
 use std::{fmt, thread};
 
 use tokio::runtime::Handle;
@@ -75,7 +77,11 @@ impl<'a> SnaprBuilder<'a> {
     }
 }
 
-impl_snapr_builder!(SnaprBuilder<'a>, Snapr<'a>, AsyncTileFetcher<'a>);
+impl_snapr_builder!(
+    (SnaprBuilder<'a>, SnaprBuilder),
+    (Snapr<'a>, Snapr),
+    (AsyncTileFetcher<'a>, AsyncTileFetcher)
+);
 
 impl<'a> fmt::Debug for SnaprBuilder<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/snapr/src/tokio.rs
+++ b/snapr/src/tokio.rs
@@ -121,9 +121,7 @@ impl<'a> BatchTileFetcher for TokioTileFetcher<'a> {
                 })
             });
 
-            spawned.join().expect(
-                "the inner `spawned` thread of a `TokioTileFetcher` is not expected to panic",
-            )
+            spawned.join().map_err(|_| Error::AsynchronousTaskPanic)?
         })
     }
 }

--- a/snapr/src/tokio.rs
+++ b/snapr/src/tokio.rs
@@ -105,7 +105,10 @@ impl<'a> BatchTileFetcher for TokioTileFetcher<'a> {
                         AsyncTileFetcher::Individual(tile_fetcher) => {
                             let mut tiles = Vec::with_capacity(coordinate_matrix_size);
 
-                            // TODO: Process `tile_fetcher` calls concurrently with tasks.
+                            // TODO: In the future, we should call `tile_fetcher` concurrently via multiple tasks.
+                            // I am currently avoiding this because ""scoped"" tasks are a little bit funky, at least from what I've played with.
+                            // Anyways, we should do this so we're 1:1 with what handling `TileFetcher::Individual` is like in synchronous land (rayon).
+
                             for &(x, y) in coordinate_matrix {
                                 let tile = tile_fetcher.fetch_tile(x, y, zoom).await?;
                                 tiles.push((x, y, tile));

--- a/snapr/src/tokio.rs
+++ b/snapr/src/tokio.rs
@@ -10,15 +10,15 @@ use crate::{
 
 /// Builder structure for [`Snapr`].
 #[derive(Default)]
-pub struct SnaprBuilder<'a> {
-    tile_fetcher: Option<AsyncTileFetcher<'a>>,
+pub struct SnaprBuilder {
+    tile_fetcher: Option<AsyncTileFetcher>,
     tile_size: Option<u32>,
     height: Option<u32>,
     width: Option<u32>,
     zoom: Option<Zoom>,
 }
 
-impl<'a> SnaprBuilder<'a> {
+impl SnaprBuilder {
     /// Attempts to construct a new [`Snapr`] from the [`SnaprBuilder`].
     ///
     /// ## Example
@@ -37,7 +37,7 @@ impl<'a> SnaprBuilder<'a> {
     ///
     /// assert!(snapr.is_ok());
     /// ```
-    pub async fn build(self) -> Result<Snapr<'a>, Error> {
+    pub async fn build<'a>(self) -> Result<Snapr<'a>, Error> {
         let Some(tile_fetcher) = self.tile_fetcher else {
             return Err(Error::Builder {
                 reason: "field `tile_fetcher` needs to be set prior to a `snapr` being built"
@@ -71,9 +71,9 @@ impl<'a> SnaprBuilder<'a> {
     }
 }
 
-impl_snapr_builder!(SnaprBuilder<'a>, Snapr<'a>, AsyncTileFetcher<'a>);
+impl_snapr_builder!(SnaprBuilder, Snapr<'a>, AsyncTileFetcher);
 
-impl<'a> fmt::Debug for SnaprBuilder<'a> {
+impl fmt::Debug for SnaprBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SnaprBuilder")
             .field("tile_size", &self.tile_size)
@@ -84,12 +84,12 @@ impl<'a> fmt::Debug for SnaprBuilder<'a> {
     }
 }
 
-struct TokioTileFetcher<'a> {
+struct TokioTileFetcher {
     handle: Handle,
-    inner: AsyncTileFetcher<'a>,
+    inner: AsyncTileFetcher,
 }
 
-impl<'a> BatchTileFetcher for TokioTileFetcher<'a> {
+impl BatchTileFetcher for TokioTileFetcher {
     fn fetch_tiles(
         &self,
         coordinate_matrix: &[(i32, i32)],


### PR DESCRIPTION
## Description

Adds support for asynchronous tile fetching via `AsyncTileFetcher` and blanket implementations for runtime executors. This will allow easier pick-up time with the library since most HTTP Client Libraries are asynchronous by default, so this will make it easier to use those libraries.

The methods `Snapr` exposes are still blocking at the moment, I haven't found a _great_ way to make them asynchronous while not maintaining a seperate implementation of its logic. I suppose I could just straight up make an `async::Snapr` structure or something that just mirrors its methods with an `async` prefix, but I don't know if that does much.
